### PR TITLE
Revert "Make asm jump labels local"

### DIFF
--- a/kernels/rviv/3/bli_czgemm_rviv_asm_4vx4.h
+++ b/kernels/rviv/3/bli_czgemm_rviv_asm_4vx4.h
@@ -181,7 +181,7 @@ REALNAME:
     vxor.vv AB13_im, AB13_im, AB13_im
 
     // Handle k == 0
-    beqz loop_counter, .LMULTIPLYBETA
+    beqz loop_counter, MULTIPLYBETA
 
     add A10_ptr, A00_ptr, s0
     slli s0, s0, 1      // length of a column of A in bytes
@@ -189,7 +189,7 @@ REALNAME:
     add A11_ptr, A10_ptr, s0
 
     li tmp, 3
-    ble loop_counter, tmp, .LTAIL_UNROLL_2
+    ble loop_counter, tmp, TAIL_UNROLL_2
 
     // Preload A and B
     // Load and deinterleave A(:,l)
@@ -210,7 +210,7 @@ REALNAME:
     VLE A01_re, (A01_ptr)
     VLE A11_re, (A11_ptr)
 
-.LLOOP_UNROLL_4: // loop_counter >= 4
+LOOP_UNROLL_4: // loop_counter >= 4
     addi loop_counter, loop_counter, -4
 
     vfmacc.vf  AB00_re, B00_re, A00_re   // AB(:,0) += A(:,l) * B(l,0)
@@ -410,7 +410,7 @@ REALNAME:
     vfmacc.vf  AB13_im, B13_im, A11_re
 
     li tmp, 3
-    ble loop_counter, tmp, .LTAIL_UNROLL_2
+    ble loop_counter, tmp, TAIL_UNROLL_2
 
     // Load A and B for the next iteration
     VLE A00_re, (A00_ptr)
@@ -427,11 +427,11 @@ REALNAME:
     FLOAD B03_re, 6*REALSIZE(B_row_ptr)
     FLOAD B03_im, 7*REALSIZE(B_row_ptr)
 
-    j .LLOOP_UNROLL_4
+    j LOOP_UNROLL_4
 
-.LTAIL_UNROLL_2: // loop_counter <= 3
+TAIL_UNROLL_2: // loop_counter <= 3
     li tmp, 1
-    ble loop_counter, tmp, .LTAIL_UNROLL_1
+    ble loop_counter, tmp, TAIL_UNROLL_1
 
     addi loop_counter, loop_counter, -2
 
@@ -535,15 +535,15 @@ REALNAME:
     vfmacc.vf  AB13_im, B13_re, A11_im
     vfmacc.vf  AB13_im, B13_im, A11_re
 
-    beqz loop_counter, .LMULTIPLYALPHA
+    beqz loop_counter, MULTIPLYALPHA
 
     // Advance pointers
     add A00_ptr, A01_ptr, s0
     add A10_ptr, A11_ptr, s0
     addi B_row_ptr, B_row_ptr, 16*REALSIZE
 
-.LTAIL_UNROLL_1: // loop_counter <= 1
-    beqz loop_counter, .LMULTIPLYALPHA
+TAIL_UNROLL_1: // loop_counter <= 1
+    beqz loop_counter, MULTIPLYALPHA
 
     // Load and deinterleave A(:,l)
     VLE A00_re, (A00_ptr)
@@ -595,12 +595,12 @@ REALNAME:
     vfmacc.vf  AB13_im, B03_re, A10_im
     vfmacc.vf  AB13_im, B03_im, A10_re
 
-.LMULTIPLYALPHA:
+MULTIPLYALPHA:
     FLOAD ALPHA_re, 0*REALSIZE(a1)
     FLOAD ALPHA_im, 1*REALSIZE(a1)
 
     FEQ tmp, ALPHA_im, fzero
-    bne tmp, zero, .LALPHAREAL
+    bne tmp, zero, ALPHAREAL
 
     // [AB00, ..., AB03] * alpha
     vfmul.vf  tmp0_re, AB00_im, ALPHA_im
@@ -638,9 +638,9 @@ REALNAME:
     vfmadd.vf AB12_im, ALPHA_re, tmp2_im
     vfmadd.vf AB13_im, ALPHA_re, tmp3_im
 
-    j .LMULTIPLYBETA
+    j MULTIPLYBETA
 
-.LALPHAREAL:
+ALPHAREAL:
     vfmul.vf AB00_re, AB00_re, ALPHA_re
     vfmul.vf AB00_im, AB00_im, ALPHA_re
     vfmul.vf AB01_re, AB01_re, ALPHA_re
@@ -659,11 +659,11 @@ REALNAME:
     vfmul.vf AB13_re, AB13_re, ALPHA_re
     vfmul.vf AB13_im, AB13_im, ALPHA_re
 
-.LMULTIPLYBETA:
+MULTIPLYBETA:
     FLOAD BETA_re,  0*REALSIZE(a4)
     FLOAD BETA_im,  1*REALSIZE(a4)
     FEQ tmp, BETA_im, fzero
-    bne tmp, zero, .LBETAREAL
+    bne tmp, zero, BETAREAL
 
     // Load and deinterleave C(0:VLEN-1, 0:1)
     VLE C0_re, (C00_ptr)
@@ -733,11 +733,11 @@ REALNAME:
     vfmacc.vf   AB13_im, BETA_im, C3_re
     VSE AB13_re, (C13_ptr)
 
-    j .LEND
+    j END
 
-.LBETAREAL:
+BETAREAL:
     FEQ tmp, BETA_re, fzero
-    bne tmp, zero, .LBETAZERO
+    bne tmp, zero, BETAZERO
 
     // Load and deinterleave C(0:VLEN-1, 0:3)
     VLE C0_re, (C00_ptr)
@@ -783,9 +783,9 @@ REALNAME:
     VSE AB12_re, (C12_ptr)
     VSE AB13_re, (C13_ptr)
 
-    j .LEND
+    j END
 
-.LBETAZERO:
+BETAZERO:
     VSE AB00_re, (C00_ptr)
     VSE AB01_re, (C01_ptr)
     VSE AB02_re, (C02_ptr)
@@ -796,6 +796,6 @@ REALNAME:
     VSE AB12_re, (C12_ptr)
     VSE AB13_re, (C13_ptr)
 
-.LEND:
+END:
     #include "rviv_restore_registers.h"
     ret

--- a/kernels/rviv/3/bli_sdgemm_rviv_asm_4vx4.h
+++ b/kernels/rviv/3/bli_sdgemm_rviv_asm_4vx4.h
@@ -172,7 +172,7 @@ REALNAME:
     vxor.vv AB33, AB33, AB33
 
     // Handle k == 0
-    beqz loop_counter, .LMULTIPLYBETA
+    beqz loop_counter, MULTIPLYBETA
 
     // Set up pointers to rows of A
     add A10_ptr, A00_ptr, s0
@@ -182,7 +182,7 @@ REALNAME:
     slli s0, s0, 2 // length of a column of A in bytes
 
     li tmp, 3
-    ble loop_counter, tmp, .LTAIL_UNROLL_2
+    ble loop_counter, tmp, TAIL_UNROLL_2
 
     // Preload A and B
     // Load A(:,l)
@@ -203,7 +203,7 @@ REALNAME:
     add A21_ptr, A20_ptr, s0
     add A31_ptr, A30_ptr, s0
 
-.LLOOP_UNROLL_4:
+LOOP_UNROLL_4:
     addi loop_counter, loop_counter, -4
 
     vfmacc.vf AB00, B00, A00   // AB(0,:) += A(0,0) * B(0,:)
@@ -343,7 +343,7 @@ REALNAME:
     vfmacc.vf AB33, B13, A31
 
     li tmp, 3
-    ble loop_counter, tmp, .LTAIL_UNROLL_2
+    ble loop_counter, tmp, TAIL_UNROLL_2
 
     // Load A and B for the next iteration
     // Load B(l,0:3)
@@ -364,11 +364,11 @@ REALNAME:
     add A21_ptr, A20_ptr, s0
     add A31_ptr, A30_ptr, s0
 
-    j .LLOOP_UNROLL_4
+    j LOOP_UNROLL_4
 
-.LTAIL_UNROLL_2: // loop_counter <= 3
+TAIL_UNROLL_2: // loop_counter <= 3
     li tmp, 1
-    ble loop_counter, tmp, .LTAIL_UNROLL_1
+    ble loop_counter, tmp, TAIL_UNROLL_1
 
     addi loop_counter, loop_counter, -2
 
@@ -452,10 +452,10 @@ REALNAME:
     vfmacc.vf AB33, B13, A31
 
     li tmp, 1
-    ble loop_counter, tmp, .LTAIL_UNROLL_1
+    ble loop_counter, tmp, TAIL_UNROLL_1
 
-.LTAIL_UNROLL_1: // loop_counter <= 1
-    beqz loop_counter, .LMULTIPLYALPHA
+TAIL_UNROLL_1: // loop_counter <= 1
+    beqz loop_counter, MULTIPLYALPHA
 
     // Load row of B
     FLOAD B00, 0*DATASIZE(B_row_ptr)
@@ -489,7 +489,7 @@ REALNAME:
     vfmacc.vf AB32, B02, A30
     vfmacc.vf AB33, B03, A30
 
-.LMULTIPLYALPHA:
+MULTIPLYALPHA:
     FLOAD ALPHA, (a1)
 
     // Multiply with alpha
@@ -513,12 +513,12 @@ REALNAME:
     vfmul.vf AB32, AB32, ALPHA
     vfmul.vf AB33, AB33, ALPHA
 
-.LMULTIPLYBETA:
+MULTIPLYBETA:
     FLOAD BETA,  (a4)
     FEQ tmp, BETA, fzero
-    beq tmp, zero, .LBETANOTZERO
+    beq tmp, zero, BETANOTZERO
 
-.LBETAZERO:
+BETAZERO:
     VSE AB00, (C00_ptr)
     VSE AB01, (C01_ptr)
     VSE AB02, (C02_ptr)
@@ -549,9 +549,9 @@ REALNAME:
     VSE AB32, (C12_ptr)
     VSE AB33, (C13_ptr)
 
-    j .LEND
+    j END
 
-.LBETANOTZERO:
+BETANOTZERO:
     VLE C00, (C00_ptr)  // Load C(0:VLEN-1, 0:3)
     VLE C01, (C01_ptr)
     VLE C02, (C02_ptr)
@@ -622,6 +622,6 @@ REALNAME:
     VSE AB32, (C12_ptr)
     VSE AB33, (C13_ptr)
 
-.LEND:
+END:
     #include "rviv_restore_registers.h"
     ret


### PR DESCRIPTION
This reverts commit 935b39f2385c096dbfe6fa27121b2f1501211fe8.

`.L` `L` `L$` prefixes are neither necessary nor desirable for assembly source code, because assembly code labels are always of internal linkage (static), and do not cause conflicts with other compilation units (object files), unless `.global` is used to make them global, and they appear in more than one object file.

Assembly kernel labels do not need to be made into "Local Symbols", which are symbols which are totally omitted from debugging and symbol table output `*`, and hence are unable to be used as breakpoint names, or even seen as descriptive label names during step-by-step debugging, or profiled as being the locations of hotspots.

(`*` Unless `as -L` is used.)

"Local Labels" use only digits, which are even harder to read. The main motivation for local labels is during `m4` macro expansion, when a snippet of code needs a label whose relative position in the code is always forward or backward from all branches to it, and hence it can be done such as:

```
define(`macro1',`
 beqz loop_counter, 1f
 nop
1:
')

define(`macro2',`
1:
 nop
 bnez loop_counter, 1b
')

macro1
macro2    ; no conflict in label 1 -- it gets reused
```
The assembler automatically turns these numbered "Local Labels" into regularly-named "Local Symbols" like `label_1`, `label_2`, etc., which are then optionally outputted in the object file if `as -L` is specified.  The numbers can be reused later with no ambiguity, because the forward and backward branches and the label form a local range.  It only makes sense in `m4` macros, where the "local label" is "local to the macro".

If removal of all non-global symbols from an object file is desired because it is unwanted debugging information that is making the object file too large, or is sharing non-public internal details, then you can use `strip -x` instead, without having to use weird naming conventions which are not standard across object file formats, and which make the source code harder to read and maintain.

Using periods at the beginning of labels to make them "Local Symbols" confuses some syntax highlighting and auto-indenting editors, because it looks like a pseudo-op, and since a pseudo-op must appear in the second column or later, the editor might automatically indent it if the first character typed on the line is `.`. If you really wanted a label, you will have to manually un-indent it, since labels must start in the first column.

The mangling of symbol names for locality conventions is the job of the assembler or object code generator, not the assembly code author.

References:

https://sourceware.org/binutils/docs/as/Symbol-Names.html 
https://sourceware.org/binutils/docs-2.18/as/Symbol-Names.html 
https://stackoverflow.com/questions/51150860/assembly-label-prefixes
