### PR TITLE
assert( rs_c == 1 ) and remove unnecessary multiplication by rs_c

### DIFF
--- a/kernels/rviv/3/bli_cgemm_rviv_4vx4.c
+++ b/kernels/rviv/3/bli_cgemm_rviv_4vx4.c
@@ -69,9 +69,11 @@ void bli_cgemm_rviv_4vx4
 
     GEMM_UKR_SETUP_CT( c, mr, nr, false );
 
-    // Assumes rs_c == 1.
+    // The kernel assumes rs_c == 1, and the context should not deviate from it.
+    assert( rs_c == 1 );
+
     bli_cgemm_rviv_asm_4vx4( k, alpha, a, b, beta, c,
-                             rs_c * get_vlenb() * 2, cs_c * sizeof(scomplex));
+                             get_vlenb() * 2, cs_c * sizeof(scomplex) );
 
     GEMM_UKR_FLUSH_CT( c );
 }

--- a/kernels/rviv/3/bli_dgemm_rviv_4vx4.c
+++ b/kernels/rviv/3/bli_dgemm_rviv_4vx4.c
@@ -69,9 +69,11 @@ void bli_dgemm_rviv_4vx4
 
     GEMM_UKR_SETUP_CT( d, mr, nr, false );
 
-    // Assumes rs_c == 1.
+    // The kernel assumes rs_c == 1, and the context should not deviate from it.
+    assert( rs_c == 1 );
+
     bli_dgemm_rviv_asm_4vx4( k, alpha, a, b, beta, c,
-                             rs_c * get_vlenb(), cs_c * sizeof(double) );
+                             get_vlenb(), cs_c * sizeof(double) );
 
     GEMM_UKR_FLUSH_CT( d );
 }

--- a/kernels/rviv/3/bli_rviv_utils.h
+++ b/kernels/rviv/3/bli_rviv_utils.h
@@ -33,6 +33,7 @@
 */
 
 #include "blis.h"
+#include <assert.h>
 
 static inline uintptr_t get_vlenb(void)
 {

--- a/kernels/rviv/3/bli_sgemm_rviv_4vx4.c
+++ b/kernels/rviv/3/bli_sgemm_rviv_4vx4.c
@@ -70,9 +70,11 @@ void bli_sgemm_rviv_4vx4
 
     GEMM_UKR_SETUP_CT( s, mr, nr, false );
 
-    // Assumes rs_c == 1.
+    // The kernel assumes rs_c == 1, and the context should not deviate from it.
+    assert( rs_c == 1 );
+
     bli_sgemm_rviv_asm_4vx4( k, alpha, a, b, beta, c,
-                             rs_c * get_vlenb(), cs_c * sizeof(float) );
+                             get_vlenb(), cs_c * sizeof(float) );
 
     GEMM_UKR_FLUSH_CT( s );
 }

--- a/kernels/rviv/3/bli_zgemm_rviv_4vx4.c
+++ b/kernels/rviv/3/bli_zgemm_rviv_4vx4.c
@@ -70,9 +70,11 @@ void bli_zgemm_rviv_4vx4
 
     GEMM_UKR_SETUP_CT( z, mr, nr, false );
 
-    // Assumes rs_c == 1.
+    // The kernel assumes rs_c == 1, and the context should not deviate from it.
+    assert( rs_c == 1 );
+
     bli_zgemm_rviv_asm_4vx4( k, alpha, a, b, beta, c,
-                             rs_c * get_vlenb() * 2, cs_c * sizeof(dcomplex) );
+                             get_vlenb() * 2, cs_c * sizeof(dcomplex) );
 
     GEMM_UKR_FLUSH_CT( z );
 }


### PR DESCRIPTION
Add assertion checks in the kernels to ensure that the context sets `rs_c == 1`. After this check, remove the unnecessary multiplication by `rs_c`, which will be expensive on machines without `M` extension.

