### PR TITLE
Implement autodetection for RISC-V

### DIFF
--- a/configure
+++ b/configure
@@ -1228,14 +1228,25 @@ auto_detect()
 	# NOTE: -D_GNU_SOURCE is needed to enable POSIX extensions to
 	# pthreads (i.e., barriers).
 
-	cmd="${cc} ${config_defines} \
+	cmd="${cc} \
 	      -DBLIS_CONFIGURETIME_CPUID \
 	      ${c_hdr_paths} \
 	      -std=c99 -D_GNU_SOURCE \
-	      ${cflags} \
-	      ${c_src_filepaths} \
-	      ${ldflags} \
-	      -o ${autodetect_x}"
+	      ${cflags}"
+
+    # Special case for RISC-V, whose architecture can be detected with
+    # preprocessor macros alone. This avoids having to run RISC-V binaries
+    # on a cross-compiler host. Returns "generic" if RISC-V not detected.
+    riscv_config=$(${cmd} -E "${dist_path}/frame/base/bli_riscv_cpuid.h" |
+                       grep '^[^#]')
+    if [[ $riscv_config != *generic* ]]; then
+        echo "${riscv_config}"
+        return
+    fi
+
+    # Finish command for building executable
+    cmd="${cmd} ${config_defines} ${c_src_filepaths} ${ldflags} \
+         -o ${autodetect_x}"
 
 	if [ "${debug_auto_detect}" == "no" ]; then
 
@@ -4601,4 +4612,3 @@ main()
 
 # The script's main entry point, passing all parameters given.
 main "$@"
-

--- a/frame/base/bli_riscv_cpuid.h
+++ b/frame/base/bli_riscv_cpuid.h
@@ -1,15 +1,67 @@
-#if __riscv_xlen >= 64
-#if __riscv_vector
+/*
+
+   BLIS
+   An object-based framework for developing high-performance BLAS-like
+   libraries.
+
+   Copyright (C) 2023, The University of Texas at Austin
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+    - Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    - Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    - Neither the name(s) of the copyright holder(s) nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+*/
+
+/* RISC-V autodetection code which works with native or cross-compilers.
+   Compile with $CC -E and ignore all output lines starting with #.  On RISC-V
+   it may return rv32i (base 32-bit integer RISC-V), rv32iv (rv32i plus vector
+   extensions), rv64i (base 64-bit integer RISC-V), or rv64iv (rv64i plus
+   vector extensions). On 128-bit integer RISC-V, it falls back to generic
+   for now. For toolchains which do not yet support RISC-V feature-detection
+   macros, it will fall back on generic, so the BLIS configure script may need
+   the RISC-V configuration to be explicitly specified. */
+
+// false if !defined(riscv_i) || !defined(__riscv_xlen)
+#if __riscv_i && __riscv_xlen == 64
+
+#if __riscv_vector // false if !defined(__riscv_vector)
 rv64iv
 #else
 rv64i
 #endif
-#elif __riscv_xlen >= 32
-#if __riscv_vector
+
+// false if !defined(riscv_i) || !defined(__riscv_xlen)
+#elif __riscv_i && __riscv_xlen == 32
+
+#if __riscv_vector // false if !defined(__riscv_vector)
 rv32iv
 #else
 rv32i
 #endif
+
 #else
-generic
+
+generic  // fall back on BLIS runtime CPUID autodetection algorithm
+
 #endif

--- a/frame/base/bli_riscv_cpuid.h
+++ b/frame/base/bli_riscv_cpuid.h
@@ -1,0 +1,15 @@
+#if __riscv_xlen >= 64
+#if __riscv_vector
+rv64iv
+#else
+rv64i
+#endif
+#elif __riscv_xlen >= 32
+#if __riscv_vector
+rv32iv
+#else
+rv32i
+#endif
+#else
+generic
+#endif

--- a/kernels/rviv/3/rviv_restore_registers.h
+++ b/kernels/rviv/3/rviv_restore_registers.h
@@ -33,7 +33,24 @@
 */
 
 
-#if RISCV_SIZE == 64
+// 128-bit RISC-V is assumed to support the __riscv_xlen test macro
+#if __riscv_xlen == 128  // false if !defined(__riscv_xlen)
+
+    lq s7, 112(sp)
+    lq s6,  96(sp)
+    lq s5,  80(sp)
+    lq s4,  64(sp)
+    lq s3,  48(sp)
+    lq s2,  32(sp)
+    lq s1,  16(sp)
+    lq s0,   0(sp)
+    addi sp, sp, 128
+
+// 64-bit RISC-V can be indicated by either __riscv_xlen == 64 or
+// RISCV_SIZE == 64, to support toolchains which do not currently
+// support __riscv_xlen. If a macro is undefined, it is considered 0.
+#elif __riscv_xlen == 64 || RISCV_SIZE == 64
+
     ld s7, 56(sp)
     ld s6, 48(sp)
     ld s5, 40(sp)
@@ -42,15 +59,19 @@
     ld s2, 16(sp)
     ld s1,  8(sp)
     ld s0,  0(sp)
-#else
-    lw s7, 56(sp)
-    lw s6, 48(sp)
-    lw s5, 40(sp)
-    lw s4, 32(sp)
-    lw s3, 24(sp)
-    lw s2, 16(sp)
-    lw s1,  8(sp)
-    lw s0,  0(sp)
-#endif
+    addi sp, sp, 64
 
-    addi sp,sp,64
+#else
+// else 32-bit RISC-V is assumed
+
+    lw s7, 28(sp)
+    lw s6, 24(sp)
+    lw s5, 20(sp)
+    lw s4, 16(sp)
+    lw s3, 12(sp)
+    lw s2,  8(sp)
+    lw s1,  4(sp)
+    lw s0,  0(sp)
+    addi sp, sp, 32
+
+#endif

--- a/kernels/rviv/3/rviv_save_registers.h
+++ b/kernels/rviv/3/rviv_save_registers.h
@@ -33,9 +33,25 @@
 
 */
 
-    addi sp,sp,-64
+// 128-bit RISC-V is assumed to support the __riscv_xlen test macro
+#if __riscv_xlen == 128  // false if !defined(__riscv_xlen)
 
-#if RISCV_SIZE == 64
+    addi sp, sp, -128
+    sq s7, 112(sp)
+    sq s6,  96(sp)
+    sq s5,  80(sp)
+    sq s4,  64(sp)
+    sq s3,  48(sp)
+    sq s2,  32(sp)
+    sq s1,  16(sp)
+    sq s0,   0(sp)
+
+// 64-bit RISC-V can be indicated by either __riscv_xlen == 64 or
+// RISCV_SIZE == 64, to support toolchains which do not currently
+// support __riscv_xlen. If a macro is undefined, it is considered 0.
+#elif __riscv_xlen == 64 || RISCV_SIZE == 64
+
+    addi sp, sp, -64
     sd s7, 56(sp)
     sd s6, 48(sp)
     sd s5, 40(sp)
@@ -44,13 +60,18 @@
     sd s2, 16(sp)
     sd s1,  8(sp)
     sd s0,  0(sp)
+
 #else
-    sw s7, 56(sp)
-    sw s6, 48(sp)
-    sw s5, 40(sp)
-    sw s4, 32(sp)
-    sw s3, 24(sp)
-    sw s2, 16(sp)
-    sw s1,  8(sp)
+// else 32-bit RISC-V is assumed
+
+    addi sp, sp, -32
+    sw s7, 28(sp)
+    sw s6, 24(sp)
+    sw s5, 20(sp)
+    sw s4, 16(sp)
+    sw s3, 12(sp)
+    sw s2,  8(sp)
+    sw s1,  4(sp)
     sw s0,  0(sp)
+
 #endif


### PR DESCRIPTION
Implement autodetection for RISC-V, whose architecture can be detected with preprocessor macros alone. This avoids having to run RISC-V binaries on a cross-compiler host.
