### PR TITLE
Set -march= flag based on available features rather than the base config

### DIFF
--- a/config/rv32i/make_defs.mk
+++ b/config/rv32i/make_defs.mk
@@ -48,7 +48,8 @@ THIS_CONFIG    := rv32i
 CPPROCFLAGS    := -DRISCV_SIZE=32
 # Atomic instructions must be enabled either via hardware
 # (-march=rv32ia) or by linking against libatomic
-CMISCFLAGS     := -march=rv32i -mabi=ilp32
+CMISCFLAGS     := -march=$(shell $(CC) -E frame/base/bli_riscv_detect_arch.h \
+							| grep '^[^#]') -mabi=ilp32
 CPICFLAGS      :=
 CWARNFLAGS     := -Wall -Wno-unused-function -Wfatal-errors
 

--- a/config/rv32iv/make_defs.mk
+++ b/config/rv32iv/make_defs.mk
@@ -48,7 +48,8 @@ THIS_CONFIG    := rv32iv
 CPPROCFLAGS    := -DRISCV_SIZE=32
 # Atomic instructions must be enabled either via hardware
 # (-march=rv32iav) or by linking against libatomic
-CMISCFLAGS     := -march=rv32iv -mabi=ilp32d
+CMISCFLAGS     := -march=$(shell $(CC) -E frame/base/bli_riscv_detect_arch.h \
+							| grep '^[^#]') -mabi=ilp32d
 CPICFLAGS      :=
 CWARNFLAGS     := -Wall -Wno-unused-function -Wfatal-errors
 

--- a/config/rv64i/make_defs.mk
+++ b/config/rv64i/make_defs.mk
@@ -46,7 +46,8 @@ THIS_CONFIG    := rv64i
 # general-purpose/configuration-agnostic flags in common.mk. You
 # may specify additional flags here as needed.
 CPPROCFLAGS    := -DRISCV_SIZE=64
-CMISCFLAGS     := -march=rv64i -mabi=lp64
+CMISCFLAGS     := -march=$(shell $(CC) -E frame/base/bli_riscv_detect_arch.h \
+							| grep '^[^#]') -mabi=lp64
 CPICFLAGS      :=
 CWARNFLAGS     := -Wall -Wno-unused-function -Wfatal-errors
 

--- a/config/rv64iv/make_defs.mk
+++ b/config/rv64iv/make_defs.mk
@@ -46,7 +46,8 @@ THIS_CONFIG    := rv64iv
 # general-purpose/configuration-agnostic flags in common.mk. You
 # may specify additional flags here as needed.
 CPPROCFLAGS    := -DRISCV_SIZE=64
-CMISCFLAGS     := -march=rv64iv -mabi=lp64d
+CMISCFLAGS     := -march=$(shell $(CC) -E frame/base/bli_riscv_detect_arch.h \
+							| grep '^[^#]') -mabi=lp64d
 CPICFLAGS      :=
 CWARNFLAGS     := -Wall -Wno-unused-function -Wfatal-errors
 

--- a/frame/base/bli_riscv_detect_arch.h
+++ b/frame/base/bli_riscv_detect_arch.h
@@ -35,6 +35,10 @@
 
 /* Construct a RISC-V architecture string based on available features. */
 
+#if __riscv
+
+#if __riscv_arch_test
+
 #if __riscv_i
 #define RISCV_I i
 #else
@@ -89,10 +93,48 @@
 #define RISCV_V
 #endif
 
+#else /* __riscv_arch_test */
+
+/* We assume I and E are exclusive when __riscv_arch_test isn't defined */
+#if __riscv_32e
+#define RISCV_I
+#define RISCV_E e
+#else
+#define RISCV_I i
+#define RISCV_E
+#endif
+
+#if __riscv_flen >= 32
+#define RISCV_F f
+#else
+#define RISCV_F
+#endif
+
+#if __riscv_flen >= 64
+#define RISCV_D d
+#else
+#define RISCV_D
+#endif
+
+/* Cannot test for M, A, C, P if __riscv_arch_test isn't defined */
+#define RISCV_M
+#define RISCV_A
+#define RISCV_C
+#define RISCV_P
+
+#if __riscv_vector
+#define RISCV_V v
+#else
+#define RISCV_V
+#endif
+
+#endif /* __riscv_arch_test */
+
 #define CAT2(a,b) a##b
 #define CAT(a,b) CAT2(a,b)
 
-#if __riscv_i && __riscv_m && __riscv_a && __riscv_f && __riscv_d && !__riscv_e
+#if __riscv_arch_test &&__riscv_i && __riscv_m && __riscv_a && \
+    __riscv_f && __riscv_d && !__riscv_e
 
 CAT(rv, CAT(__riscv_xlen, CAT(g, CAT(RISCV_C, CAT(RISCV_P, RISCV_V)))))
 
@@ -102,3 +144,5 @@ CAT(rv, CAT(__riscv_xlen, CAT(RISCV_I, CAT(RISCV_E, CAT(RISCV_M, CAT(RISCV_A,
 CAT(RISCV_F, CAT(RISCV_D, CAT(RISCV_C, CAT(RISCV_P, RISCV_V))))))))))
 
 #endif
+
+#endif /* __riscv */

--- a/frame/base/bli_riscv_detect_arch.h
+++ b/frame/base/bli_riscv_detect_arch.h
@@ -133,8 +133,8 @@
 #define CAT2(a,b) a##b
 #define CAT(a,b) CAT2(a,b)
 
-#if __riscv_arch_test &&__riscv_i && __riscv_m && __riscv_a && \
-    __riscv_f && __riscv_d && !__riscv_e
+#if __riscv_arch_test && ( __riscv_i && __riscv_m && __riscv_a && \
+						   __riscv_f && __riscv_d && !__riscv_e)
 
 CAT(rv, CAT(__riscv_xlen, CAT(g, CAT(RISCV_C, CAT(RISCV_P, RISCV_V)))))
 

--- a/frame/base/bli_riscv_detect_arch.h
+++ b/frame/base/bli_riscv_detect_arch.h
@@ -1,0 +1,104 @@
+/*
+
+   BLIS
+   An object-based framework for developing high-performance BLAS-like
+   libraries.
+
+   Copyright (C) 2023, The University of Texas at Austin
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+    - Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    - Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    - Neither the name(s) of the copyright holder(s) nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+*/
+
+/* Construct a RISC-V architecture string based on available features. */
+
+#if __riscv_i
+#define RISCV_I i
+#else
+#define RISCV_I
+#endif
+
+#if __riscv_e
+#define RISCV_E e
+#else
+#define RISCV_E
+#endif
+
+#if __riscv_m
+#define RISCV_M m
+#else
+#define RISCV_M
+#endif
+
+#if __riscv_a
+#define RISCV_A a
+#else
+#define RISCV_A
+#endif
+
+#if __riscv_f
+#define RISCV_F f
+#else
+#define RISCV_F
+#endif
+
+#if __riscv_d
+#define RISCV_D d
+#else
+#define RISCV_D
+#endif
+
+#if __riscv_c
+#define RISCV_C c
+#else
+#define RISCV_C
+#endif
+
+#if __riscv_p
+#define RISCV_P p
+#else
+#define RISCV_P
+#endif
+
+#if __riscv_v
+#define RISCV_V v
+#else
+#define RISCV_V
+#endif
+
+#define CAT2(a,b) a##b
+#define CAT(a,b) CAT2(a,b)
+
+#if __riscv_i && __riscv_m && __riscv_a && __riscv_f && __riscv_d && !__riscv_e
+
+CAT(rv, CAT(__riscv_xlen, CAT(g, CAT(RISCV_C, CAT(RISCV_P, RISCV_V)))))
+
+#else
+
+CAT(rv, CAT(__riscv_xlen, CAT(RISCV_I, CAT(RISCV_E, CAT(RISCV_M, CAT(RISCV_A,
+CAT(RISCV_F, CAT(RISCV_D, CAT(RISCV_C, CAT(RISCV_P, RISCV_V))))))))))
+
+#endif

--- a/frame/base/bli_riscv_detect_arch.h
+++ b/frame/base/bli_riscv_detect_arch.h
@@ -134,7 +134,7 @@
 #define RISCV_C
 #endif
 
-#define RISV_P
+#define RISCV_P
 
 #if __riscv_vector
 #define RISCV_V v

--- a/frame/base/bli_riscv_detect_arch.h
+++ b/frame/base/bli_riscv_detect_arch.h
@@ -104,6 +104,18 @@
 #define RISCV_E
 #endif
 
+#if __riscv_mul
+#define RISCV_M m
+#else
+#define RISCV_M
+#endif
+
+#if __riscv_atomic
+#define RISCV_A a
+#else
+#define RISCV_A
+#endif
+
 #if __riscv_flen >= 32
 #define RISCV_F f
 #else
@@ -116,11 +128,13 @@
 #define RISCV_D
 #endif
 
-/* Cannot test for M, A, C, P if __riscv_arch_test isn't defined */
-#define RISCV_M
-#define RISCV_A
+#if __riscv_compressed
+#define RISCV_C c
+#else
 #define RISCV_C
-#define RISCV_P
+#endif
+
+#define RISV_P
 
 #if __riscv_vector
 #define RISCV_V v
@@ -133,16 +147,7 @@
 #define CAT2(a,b) a##b
 #define CAT(a,b) CAT2(a,b)
 
-#if __riscv_arch_test && ( __riscv_i && __riscv_m && __riscv_a && \
-						   __riscv_f && __riscv_d && !__riscv_e)
-
-CAT(rv, CAT(__riscv_xlen, CAT(g, CAT(RISCV_C, CAT(RISCV_P, RISCV_V)))))
-
-#else
-
 CAT(rv, CAT(__riscv_xlen, CAT(RISCV_I, CAT(RISCV_E, CAT(RISCV_M, CAT(RISCV_A,
 CAT(RISCV_F, CAT(RISCV_D, CAT(RISCV_C, CAT(RISCV_P, RISCV_V))))))))))
-
-#endif
 
 #endif /* __riscv */

--- a/frame/include/bli_misc_macro_defs.h
+++ b/frame/include/bli_misc_macro_defs.h
@@ -171,6 +171,6 @@ BLIS_INLINE void bli_toggle_bool( bool* b )
 
 
 // Static assertion compatible with any version of C/C++
-#define bli_static_assert(cond) while(0){struct s {int bli_static_assert : !!(cond);};}
+#define bli_static_assert(cond) while(0){struct s {int STATIC_ASSERT_FAILED : !!(cond);};}
 
 #endif


### PR DESCRIPTION
Set `-march=` flag based on available features rather than forcing it to the base configuration (`rv32i`, `rv32iv`, `rv64i`, `rv64iv`). Might be the same as leaving `-march=` out entirely.