### PR TITLE
Refine RISC-V autodetection, get RISC-V Clang working with BLIS

### DIFF
--- a/config/rv32iv/make_defs.mk
+++ b/config/rv32iv/make_defs.mk
@@ -48,7 +48,7 @@ THIS_CONFIG    := rv32iv
 CPPROCFLAGS    := -DRISCV_SIZE=32
 # Atomic instructions must be enabled either via hardware
 # (-march=rv32iav) or by linking against libatomic
-CMISCFLAGS     := -march=$(shell $(CC) -E frame/base/bli_riscv_detect_arch.h \
+CMISCFLAGS     := -march=$(shell $(CC) -DFORCE_RISCV_VECTOR -E frame/base/bli_riscv_detect_arch.h \
 							| grep '^[^#]') -mabi=ilp32d
 CPICFLAGS      :=
 CWARNFLAGS     := -Wall -Wno-unused-function -Wfatal-errors

--- a/config/rv32iv/make_defs.mk
+++ b/config/rv32iv/make_defs.mk
@@ -48,8 +48,7 @@ THIS_CONFIG    := rv32iv
 CPPROCFLAGS    := -DRISCV_SIZE=32
 # Atomic instructions must be enabled either via hardware
 # (-march=rv32iav) or by linking against libatomic
-CMISCFLAGS     := -march=$(shell $(CC) -DFORCE_RISCV_VECTOR -E frame/base/bli_riscv_detect_arch.h \
-							| grep '^[^#]') -mabi=ilp32d
+CMISCFLAGS     := -march=$(shell $(CC) -DFORCE_RISCV_VECTOR -E frame/base/bli_riscv_detect_arch.h | grep '^[^\#]') -mabi=ilp32d
 CPICFLAGS      :=
 CWARNFLAGS     := -Wall -Wno-unused-function -Wfatal-errors
 

--- a/config/rv64iv/make_defs.mk
+++ b/config/rv64iv/make_defs.mk
@@ -46,8 +46,7 @@ THIS_CONFIG    := rv64iv
 # general-purpose/configuration-agnostic flags in common.mk. You
 # may specify additional flags here as needed.
 CPPROCFLAGS    := -DRISCV_SIZE=64
-CMISCFLAGS     := -march=$(shell $(CC) -DFORCE_RISCV_VECTOR -E frame/base/bli_riscv_detect_arch.h \
-							| grep '^[^#]') -mabi=lp64d
+CMISCFLAGS     := -march=$(shell $(CC) -DFORCE_RISCV_VECTOR -E frame/base/bli_riscv_detect_arch.h | grep '^[^\#]') -mabi=lp64d
 CPICFLAGS      :=
 CWARNFLAGS     := -Wall -Wno-unused-function -Wfatal-errors
 

--- a/config/rv64iv/make_defs.mk
+++ b/config/rv64iv/make_defs.mk
@@ -46,7 +46,7 @@ THIS_CONFIG    := rv64iv
 # general-purpose/configuration-agnostic flags in common.mk. You
 # may specify additional flags here as needed.
 CPPROCFLAGS    := -DRISCV_SIZE=64
-CMISCFLAGS     := -march=$(shell $(CC) -E frame/base/bli_riscv_detect_arch.h \
+CMISCFLAGS     := -march=$(shell $(CC) -DFORCE_RISCV_VECTOR -E frame/base/bli_riscv_detect_arch.h \
 							| grep '^[^#]') -mabi=lp64d
 CPICFLAGS      :=
 CWARNFLAGS     := -Wall -Wno-unused-function -Wfatal-errors

--- a/frame/base/bli_riscv_cpuid.h
+++ b/frame/base/bli_riscv_cpuid.h
@@ -42,8 +42,8 @@
    macros, it will fall back on generic, so the BLIS configure script may need
    the RISC-V configuration to be explicitly specified. */
 
-// false if !defined(riscv_i) || !defined(__riscv_xlen)
-#if __riscv_i && __riscv_xlen == 64
+// false if !defined(__riscv) || !defined(__riscv_xlen)
+#if __riscv && __riscv_xlen == 64
 
 #if __riscv_vector // false if !defined(__riscv_vector)
 rv64iv
@@ -51,8 +51,8 @@ rv64iv
 rv64i
 #endif
 
-// false if !defined(riscv_i) || !defined(__riscv_xlen)
-#elif __riscv_i && __riscv_xlen == 32
+// false if !defined(__riscv) || !defined(__riscv_xlen) || __riscv_e32 != 0
+#elif __riscv && __riscv_xlen == 32 && !__riscv_e32
 
 #if __riscv_vector // false if !defined(__riscv_vector)
 rv32iv

--- a/frame/base/bli_riscv_detect_arch.h
+++ b/frame/base/bli_riscv_detect_arch.h
@@ -87,7 +87,8 @@
 #define RISCV_P
 #endif
 
-#if __riscv_v
+/* FORCE_RISCV_VECTOR is a Clang workaround */
+#if __riscv_v || FORCE_RISCV_VECTOR
 #define RISCV_V v
 #else
 #define RISCV_V
@@ -136,7 +137,8 @@
 
 #define RISCV_P
 
-#if __riscv_vector
+/* FORCE_RISCV_VECTOR is a Clang workaround */
+#if __riscv_vector || FORCE_RISCV_VECTOR
 #define RISCV_V v
 #else
 #define RISCV_V

--- a/kernels/rviv/3/bli_czgemm_rviv_asm_4vx4.h
+++ b/kernels/rviv/3/bli_czgemm_rviv_asm_4vx4.h
@@ -148,7 +148,7 @@
 REALNAME:
 	#include "rviv_save_registers.h"
 
-	vsetvli s0, zero, VTYPE
+	vsetvli s0, zero, VTYPE, m1, ta, ma
 	csrr s0, vlenb
 	slli s0, s0, 1
 	FZERO(fzero)

--- a/kernels/rviv/3/bli_sdgemm_rviv_asm_4vx4.h
+++ b/kernels/rviv/3/bli_sdgemm_rviv_asm_4vx4.h
@@ -140,7 +140,7 @@
 REALNAME:
 	#include "rviv_save_registers.h"
 
-	vsetvli s0, zero, VTYPE
+	vsetvli s0, zero, VTYPE, m1, ta, ma
 	csrr s0, vlenb
 	FZERO(fzero)
 


### PR DESCRIPTION
Refine `bli_riscv_cpuid.h` to exclude `__riscv_32e` instead of testing for `__riscv_e`.

Add `-DFORCE_RISCV_VECTOR` when autodetecting architecture and `rv32iv` or `rv64iv` config has been selected, to work around Clang.

Fix `vsetvli` instructions to use all operands, which are not optional in Clang.

Passes quick test.